### PR TITLE
Use jar from bootJar task in copyJar, update task dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,13 +172,13 @@ def buildDir = 'build/libs/'
 def jarName = 'iexec-worker.jar'
 def jarPath = buildDir + jarName
 
-task copyJar(type: Copy) {
+task copyBootJar(type: Copy) {
     dependsOn bootJar
     from(tasks.bootJar.outputs.files.singleFile)
     into(buildDir)
     rename(tasks.bootJar.outputs.files.singleFile.name, jarName)
 }
-build.dependsOn copyJar
+build.dependsOn copyBootJar
 
 // ##################
 // #     docker     #

--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,6 @@ task copyBootJar(type: Copy) {
     into(buildDir)
     rename(tasks.bootJar.outputs.files.singleFile.name, jarName)
 }
-build.dependsOn copyBootJar
 
 // ##################
 // #     docker     #
@@ -196,6 +195,7 @@ project.ext.getDockerImageNameShortCommit = {
 }
 
 docker {
+    dependsOn copyBootJar
     name getDockerImageNameFull()
     tags 'dev'
     dockerfile file('Dockerfile')

--- a/build.gradle
+++ b/build.gradle
@@ -173,12 +173,10 @@ def jarName = 'iexec-worker.jar'
 def jarPath = buildDir + jarName
 
 task copyJar(type: Copy) {
-    dependsOn jar
-    from(buildDir + tasks.jar.archiveFile.get().asFile.getName())
+    dependsOn bootJar
+    from(tasks.bootJar.outputs.files.singleFile)
     into(buildDir)
-    rename { filename ->
-        filename.replace tasks.jar.archiveFile.get().asFile.getName(), jarName
-    }
+    rename(tasks.bootJar.outputs.files.singleFile.name, jarName)
 }
 build.dependsOn copyJar
 


### PR DESCRIPTION
The problem was as follow:

Before PR https://github.com/iExecBlockchainComputing/iexec-worker/pull/416, `jar` and `bootJar` were configured to produce a jar with the same name.
The `copyJar` task had a dependency on `jar` and the spring boot jar was copied because it was the last to be produced.

After the PR, 2 archives were produced and `jar` and `bootJar` outputs were no more the same.
The `copyJar` had to be updated to copy the spring boot jar and not the jar with only the library classes.

This is fixed with the current PR