### PR TITLE
Fix exit code report

### DIFF
--- a/src/main/java/com/iexec/worker/compute/ComputeStageConverter.java
+++ b/src/main/java/com/iexec/worker/compute/ComputeStageConverter.java
@@ -19,6 +19,10 @@ package com.iexec.worker.compute;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
+/**
+ * This class is needed to have a case-insensitive `stage` path variable in
+ * {@link ComputeController#sendExitCauseForGivenComputeStage}.
+ */
 @Component
 public class ComputeStageConverter implements Converter<String, ComputeStage> {
     @Override

--- a/src/main/java/com/iexec/worker/compute/ComputeStageConverter.java
+++ b/src/main/java/com/iexec/worker/compute/ComputeStageConverter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 IEXEC BLOCKCHAIN TECH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.iexec.worker.compute;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ComputeStageConverter implements Converter<String, ComputeStage> {
+    @Override
+    public ComputeStage convert(String value) {
+        return ComputeStage.valueOf(value.toUpperCase());
+    }
+}


### PR DESCRIPTION
`ComputeController#sendExitCauseForGivenComputeStage` does not currently work if `{stage}` is a lowercase `ComputeStage`. It needs some converter to work.