### PR TITLE
Bugfix/run post compute status

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ ext {
     springCloudVersion = '2021.0.0'
     gitBranch = 'git rev-parse --abbrev-ref HEAD'.execute().text.trim()
     dockerJavaVersion = '3.2.12'
+    lombokVersion = '1.18.2'
 }
 
 if (gitBranch != 'main' && gitBranch != 'master' && ! (gitBranch ==~ '(release|hotfix|support)/.*')) {
@@ -85,8 +86,10 @@ dependencies {
     implementation 'biz.paluch.logging:logstash-gelf:1.5.1'
 
     // lombok
-    compileOnly "org.projectlombok:lombok:1.18.2"
-    annotationProcessor "org.projectlombok:lombok:1.18.2"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
+    testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     // docker
     implementation "com.github.docker-java:docker-java:${dockerJavaVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -111,11 +111,6 @@ test {
             excludeTags 'slow'
         }
     }
-
-    // To avoid warnings on multiple SLF4J bindings,
-    // let's remove the Logback implementation
-    // and keep only SLF4j Test.
-    classpath = classpath.filter {!it.name.contains('logback-classic')}
 }
 
 task itest {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=7.1.0
-iexecCommonVersion=6.0.0
+iexecCommonVersion=6.0.0-NEXT-SNAPSHOT
 iexecBlockchainAdapterVersion=7.1.1
 iexecResultVersion=7.1.0
 iexecSmsVersion=7.1.0

--- a/src/main/java/com/iexec/worker/compute/ComputeManagerService.java
+++ b/src/main/java/com/iexec/worker/compute/ComputeManagerService.java
@@ -204,12 +204,9 @@ public class ComputeManagerService {
                 .build();
 
         if (!taskDescription.isTeeTask()) {
-            if (postComputeService.runStandardPostCompute(taskDescription)) {
-                postComputeResponse.setExitCause(null);
-            }
+            postComputeResponse = postComputeService.runStandardPostCompute(taskDescription);
         } else if (!secureSessionId.isEmpty()) {
-            postComputeResponse = postComputeService
-                    .runTeePostCompute(taskDescription, secureSessionId);
+            postComputeResponse = postComputeService.runTeePostCompute(taskDescription, secureSessionId);
         }
         if (!postComputeResponse.isSuccessful()) {
             return postComputeResponse;
@@ -221,6 +218,5 @@ public class ComputeManagerService {
         resultService.saveResultInfo(chainTaskId, taskDescription, computedFile);
         return postComputeResponse;
     }
-
 
 }

--- a/src/main/java/com/iexec/worker/compute/ComputeManagerService.java
+++ b/src/main/java/com/iexec/worker/compute/ComputeManagerService.java
@@ -211,9 +211,14 @@ public class ComputeManagerService {
         if (!postComputeResponse.isSuccessful()) {
             return postComputeResponse;
         }
-        ComputedFile computedFile = resultService.getComputedFile(chainTaskId);
+        ComputedFile computedFile = resultService.readComputedFile(chainTaskId);
         if (computedFile == null) {
+            postComputeResponse.setExitCause(ReplicateStatusCause.POST_COMPUTE_COMPUTED_FILE_NOT_FOUND);
             return postComputeResponse;
+        }
+        String resultDigest = resultService.computeResultDigest(computedFile);
+        if (resultDigest.isEmpty()) {
+            postComputeResponse.setExitCause(ReplicateStatusCause.POST_COMPUTE_RESULT_DIGEST_COMPUTATION_FAILED);
         }
         resultService.saveResultInfo(chainTaskId, taskDescription, computedFile);
         return postComputeResponse;

--- a/src/main/java/com/iexec/worker/compute/post/PostComputeService.java
+++ b/src/main/java/com/iexec/worker/compute/post/PostComputeService.java
@@ -66,8 +66,12 @@ public class PostComputeService {
     /**
      * This method implements the post-compute part of the workflow dedicated to standard tasks.
      * <p>
-     * This method implements almost the same algorithm thant the one executed for TEE tasks in
-     * a tee-worker-post-compute container.
+     * The algorithm is almost the same as the one executed for TEE tasks in a tee-worker-post-compute container:
+     * <ul>
+     * <li>Creation of the archive containing results as in {@code Web2ResultService#encryptAndUploadResult}
+     * <li>Send {@code computed.json} to its final folder as in {@code FlowService#sendComputedFileToHost}
+     * </ul>
+     * <p>
      * Classes names are inlined in comments for comparison.
      * @param taskDescription description of a standard task
      * @return a post compute response with a cause in case of error. The response is returned to

--- a/src/main/java/com/iexec/worker/compute/post/PostComputeService.java
+++ b/src/main/java/com/iexec/worker/compute/post/PostComputeService.java
@@ -76,14 +76,6 @@ public class PostComputeService {
      */
     public PostComputeResponse runStandardPostCompute(TaskDescription taskDescription) {
         String chainTaskId = taskDescription.getChainTaskId();
-        // result encryption is no more supported for standard tasks
-        if (!taskDescription.isTeeTask() && taskDescription.isResultEncryption()) {
-            log.error("Result encryption is not supported for standard tasks [chainTaskId:{}]", chainTaskId);
-            //TODO replace exitCause with another one
-            return PostComputeResponse.builder()
-                    .exitCause(ReplicateStatusCause.POST_COMPUTE_FAILED_UNKNOWN_ISSUE)
-                    .build();
-        }
 
         // create /output/iexec_out.zip as in Web2ResultService#encryptAndUploadResult
         // return a POST_COMPUTE_OUT_FOLDER_ZIP_FAILED error on failure

--- a/src/main/java/com/iexec/worker/compute/post/PostComputeService.java
+++ b/src/main/java/com/iexec/worker/compute/post/PostComputeService.java
@@ -63,6 +63,17 @@ public class PostComputeService {
         this.computeExitCauseService = computeExitCauseService;
     }
 
+    /**
+     * This method implements the post-compute part of the workflow dedicated to standard tasks.
+     * <p>
+     * This method implements almost the same algorithm thant the one executed for TEE tasks in
+     * a tee-worker-post-compute container.
+     * Classes names are inlined in comments for comparison.
+     * @param taskDescription description of a standard task
+     * @return a post compute response with a cause in case of error. The response is returned to
+     *         {@link com.iexec.worker.compute.ComputeManagerService}
+     * @see com.iexec.worker.compute.ComputeManagerService
+     */
     public PostComputeResponse runStandardPostCompute(TaskDescription taskDescription) {
         String chainTaskId = taskDescription.getChainTaskId();
         // result encryption is no more supported for standard tasks
@@ -74,7 +85,8 @@ public class PostComputeService {
                     .build();
         }
 
-        // create /output/iexec_out.zip
+        // create /output/iexec_out.zip as in Web2ResultService#encryptAndUploadResult
+        // return a POST_COMPUTE_OUT_FOLDER_ZIP_FAILED error on failure
         String zipIexecOutPath = ResultUtils.zipIexecOut(
                 workerConfigService.getTaskIexecOutDir(chainTaskId),
                 workerConfigService.getTaskOutputDir(chainTaskId));
@@ -83,7 +95,8 @@ public class PostComputeService {
                     .exitCause(ReplicateStatusCause.POST_COMPUTE_OUT_FOLDER_ZIP_FAILED)
                     .build();
         }
-        // copy /output/iexec_out/computed.json to /output/computed.json to have the same workflow as TEE.
+        // copy /output/iexec_out/computed.json to /output/computed.json as in FlowService#sendComputedFileToHost
+        // return a POST_COMPUTE_SEND_COMPUTED_FILE_FAILED error on failure
         boolean isCopied = FileHelper.copyFile(
                 workerConfigService.getTaskIexecOutDir(chainTaskId) + IexecFileHelper.SLASH_COMPUTED_JSON,
                 workerConfigService.getTaskOutputDir(chainTaskId) + IexecFileHelper.SLASH_COMPUTED_JSON);

--- a/src/main/java/com/iexec/worker/executor/TaskManagerService.java
+++ b/src/main/java/com/iexec/worker/executor/TaskManagerService.java
@@ -104,6 +104,12 @@ public class TaskManagerService {
                     context, chainTaskId);
         }
 
+        // result encryption is not supported for standard tasks
+        if (!taskDescription.isTeeTask() && taskDescription.isResultEncryption()) {
+            return getFailureResponseAndPrintError(TASK_DESCRIPTION_INVALID,
+                    context, chainTaskId);
+        }
+
         if (taskDescription.isTeeTask() && !teeSconeService.isTeeEnabled()) {
             return getFailureResponseAndPrintError(TEE_NOT_SUPPORTED,
                     context, chainTaskId);

--- a/src/test/java/com/iexec/worker/compute/ComputeManagerServiceTests.java
+++ b/src/test/java/com/iexec/worker/compute/ComputeManagerServiceTests.java
@@ -19,12 +19,10 @@ package com.iexec.worker.compute;
 import com.iexec.common.chain.WorkerpoolAuthorization;
 import com.iexec.common.dapp.DappType;
 import com.iexec.common.docker.DockerLogs;
-import com.iexec.common.docker.DockerRunFinalStatus;
 import com.iexec.common.docker.client.DockerClientInstance;
 import com.iexec.common.replicate.ReplicateStatusCause;
 import com.iexec.common.result.ComputedFile;
 import com.iexec.common.task.TaskDescription;
-import com.iexec.worker.chain.IexecHubService;
 import com.iexec.worker.compute.app.AppComputeResponse;
 import com.iexec.worker.compute.app.AppComputeService;
 import com.iexec.worker.compute.post.PostComputeResponse;
@@ -41,13 +39,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.io.File;
-import java.io.IOException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -104,8 +102,6 @@ class ComputeManagerServiceTests {
     @Mock
     private WorkerConfigurationService workerConfigurationService;
     @Mock
-    private IexecHubService iexecHubService;
-    @Mock
     private ResultService resultService;
 
     @BeforeEach
@@ -113,6 +109,7 @@ class ComputeManagerServiceTests {
         MockitoAnnotations.openMocks(this);
     }
 
+    //region downloadApp
     @Test
     void shouldDownloadApp() {
         when(dockerRegistryConfiguration.getMinPullTimeout()).thenReturn(Duration.of(5, ChronoUnit.MINUTES));
@@ -159,9 +156,9 @@ class ComputeManagerServiceTests {
         when(dockerClient.isImagePresent(taskDescription.getAppUri())).thenReturn(false);
         Assertions.assertThat(computeManagerService.isAppDownloaded(APP_URI)).isFalse();
     }
+    //endregion
 
-    // pre compute
-
+    //region runPreCompute
     @Test
     void shouldRunStandardPreCompute() {
         taskDescription.setTeeTask(false);
@@ -205,11 +202,11 @@ class ComputeManagerServiceTests {
         Assertions.assertThat(preComputeResponse.getExitCause())
                 .isEqualTo(ReplicateStatusCause.PRE_COMPUTE_DATASET_URL_MISSING);
     }
+    //endregion
 
-    // compute
-
+    //region runCompute
     @Test
-    void shouldRunStandardCompute() throws IOException {
+    void shouldRunStandardCompute() {
         taskDescription.setTeeTask(false);
         AppComputeResponse expectedDockerRunResponse =
                 AppComputeResponse.builder()
@@ -229,8 +226,7 @@ class ComputeManagerServiceTests {
         Assertions.assertThat(appComputeResponse.getStderr()).isEqualTo(
                 "stderr");
         verify(appComputeService, times(1))
-                .runCompute(taskDescription,
-                        "");
+                .runCompute(taskDescription, "");
     }
 
     @Test
@@ -255,7 +251,7 @@ class ComputeManagerServiceTests {
     }
 
     @Test
-    void shouldRunTeeCompute() throws IOException {
+    void shouldRunTeeCompute() {
         taskDescription.setTeeTask(true);
         AppComputeResponse expectedDockerRunResponse =
                 AppComputeResponse.builder()
@@ -301,36 +297,34 @@ class ComputeManagerServiceTests {
         Assertions.assertThat(appComputeResponse.getStderr()).isEqualTo(
                 "stderr");
     }
+    //endregion
 
-    // pre compute
-
+    //region runPostCompute
     @Test
     void shouldRunStandardPostCompute() {
         taskDescription.setTeeTask(false);
         when(postComputeService.runStandardPostCompute(taskDescription))
-                .thenReturn(true);
+                .thenReturn(PostComputeResponse.builder().build());
         ComputedFile computedFile = mock(ComputedFile.class);
         when(resultService.getComputedFile(CHAIN_TASK_ID)).thenReturn(computedFile);
 
         PostComputeResponse postComputeResponse =
                 computeManagerService.runPostCompute(taskDescription, "");
         Assertions.assertThat(postComputeResponse.isSuccessful()).isTrue();
-        verify(postComputeService, times(1))
-                .runStandardPostCompute(taskDescription);
-        verify(resultService, times(1))
-                .saveResultInfo(anyString(), any(), any());
+        verify(postComputeService).runStandardPostCompute(taskDescription);
+        verify(resultService).saveResultInfo(anyString(), any(), any());
     }
 
-    @Test
-    void shouldRunStandardPostComputeWithFailureResponse() {
+    @ParameterizedTest
+    @EnumSource(value = ReplicateStatusCause.class, names = "POST_COMPUTE_.*", mode = EnumSource.Mode.MATCH_ALL)
+    void shouldRunStandardPostComputeWithFailureResponse(ReplicateStatusCause statusCause) {
         taskDescription.setTeeTask(false);
-        when(postComputeService.runStandardPostCompute(taskDescription))
-                .thenReturn(false);
+        PostComputeResponse postComputeResponse = PostComputeResponse.builder().exitCause(statusCause).build();
+        when(postComputeService.runStandardPostCompute(taskDescription)).thenReturn(postComputeResponse);
 
-        PostComputeResponse postComputeResponse =
-                computeManagerService.runPostCompute(taskDescription,
-                        "");
+        postComputeResponse = computeManagerService.runPostCompute(taskDescription, "");
         Assertions.assertThat(postComputeResponse.isSuccessful()).isFalse();
+        Assertions.assertThat(postComputeResponse.getExitCause()).isEqualTo(statusCause);
     }
 
     @Test
@@ -355,10 +349,8 @@ class ComputeManagerServiceTests {
                 "stdout");
         Assertions.assertThat(postComputeResponse.getStderr()).isEqualTo(
                 "stderr");
-        verify(postComputeService, times(1))
-                .runTeePostCompute(taskDescription, SECURE_SESSION_ID);
-        verify(resultService, times(1))
-                .saveResultInfo(anyString(), any(), any());
+        verify(postComputeService).runTeePostCompute(taskDescription, SECURE_SESSION_ID);
+        verify(resultService).saveResultInfo(anyString(), any(), any());
     }
 
     @Test
@@ -383,8 +375,9 @@ class ComputeManagerServiceTests {
         Assertions.assertThat(postComputeResponse.getStderr()).isEqualTo(
                 "stderr");
     }
+    //endregion
 
-    // computeImagePullTimeout
+    //region computeImagePullTimeout
     static Stream<Arguments> computeImagePullTimeoutValues() {
         return Stream.of(
                 // maxExecutionTime, minPullTimeout, maxPullTimeout, expectedTimeout
@@ -420,4 +413,5 @@ class ComputeManagerServiceTests {
         Assertions.assertThat(computeManagerService.computeImagePullTimeout(taskDescription))
                 .isEqualTo(expectedTimeout);
     }
+    //endregion
 }

--- a/src/test/java/com/iexec/worker/compute/post/PostComputeServiceTests.java
+++ b/src/test/java/com/iexec/worker/compute/post/PostComputeServiceTests.java
@@ -108,16 +108,20 @@ class PostComputeServiceTests {
     }
 
     //region runStandardPostCompute
+    private void logDirectoryTree(String path) {
+        log.info("\n{}", FileHelper.printDirectoryTree(new File(path)));
+    }
+
     @Test
     void shouldRunStandardPostCompute() throws IOException {
         Assertions.assertThat(new File(iexecOut).mkdir()).isTrue();
         Assertions.assertThat(new File(computedJson).createNewFile()).isTrue();
-        log.info("\n{}", FileHelper.printDirectoryTree(new File(output)));
+        logDirectoryTree(output);
         when(workerConfigService.getTaskOutputDir(CHAIN_TASK_ID)).thenReturn(output);
         when(workerConfigService.getTaskIexecOutDir(CHAIN_TASK_ID)).thenReturn(iexecOut);
 
         Assertions.assertThat(postComputeService.runStandardPostCompute(taskDescription).isSuccessful()).isTrue();
-        log.info("\n{}", FileHelper.printDirectoryTree(new File(output)));
+        logDirectoryTree(output);
         Assertions.assertThat(new File(output + "/iexec_out.zip")).exists();
         Assertions.assertThat(new File(output + IexecFileHelper.SLASH_COMPUTED_JSON)).exists();
     }
@@ -126,24 +130,24 @@ class PostComputeServiceTests {
     void shouldNotRunStandardPostComputeSinceWrongSourceForZip() throws IOException {
         Assertions.assertThat(new File(iexecOut).mkdir()).isTrue();
         Assertions.assertThat(new File(computedJson).createNewFile()).isTrue();
-        log.info("\n{}", FileHelper.printDirectoryTree(new File(output)));
+        logDirectoryTree(output);
         when(workerConfigService.getTaskOutputDir(CHAIN_TASK_ID)).thenReturn(output);
         when(workerConfigService.getTaskIexecOutDir(CHAIN_TASK_ID)).thenReturn("dummyIexecOut");
 
         Assertions.assertThat(postComputeService.runStandardPostCompute(taskDescription).isSuccessful()).isFalse();
-        log.info("\n{}", FileHelper.printDirectoryTree(new File(output)));
+        logDirectoryTree(output);
     }
 
     @Test
     void shouldNotRunStandardPostComputeSinceNoComputedFileToCopy() {
         Assertions.assertThat(new File(iexecOut).mkdir()).isTrue();
         //don't create iexec_out.zip
-        log.info("\n{}", FileHelper.printDirectoryTree(new File(output)));
+        logDirectoryTree(output);
         when(workerConfigService.getTaskOutputDir(CHAIN_TASK_ID)).thenReturn(output);
         when(workerConfigService.getTaskIexecOutDir(CHAIN_TASK_ID)).thenReturn(iexecOut);
 
         Assertions.assertThat(postComputeService.runStandardPostCompute(taskDescription).isSuccessful()).isFalse();
-        log.info("\n{}", FileHelper.printDirectoryTree(new File(output)));
+        logDirectoryTree(output);
         Assertions.assertThat(new File(output + "/iexec_out.zip")).exists();
         Assertions.assertThat(new File(output + IexecFileHelper.SLASH_COMPUTED_JSON)).doesNotExist();
     }

--- a/src/test/java/com/iexec/worker/compute/post/PostComputeServiceTests.java
+++ b/src/test/java/com/iexec/worker/compute/post/PostComputeServiceTests.java
@@ -32,6 +32,7 @@ import com.iexec.worker.docker.DockerService;
 import com.iexec.worker.sgx.SgxService;
 import com.iexec.worker.tee.scone.SconeConfiguration;
 import com.iexec.worker.tee.scone.TeeSconeService;
+import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+@Slf4j
 class PostComputeServiceTests {
 
     private final static String CHAIN_TASK_ID = "CHAIN_TASK_ID";
@@ -105,20 +107,17 @@ class PostComputeServiceTests {
         computedJson = iexecOut + IexecFileHelper.SLASH_COMPUTED_JSON;
     }
 
-    /**
-     * Standard post compute
-     */
-
+    //region runStandardPostCompute
     @Test
     void shouldRunStandardPostCompute() throws IOException {
         Assertions.assertThat(new File(iexecOut).mkdir()).isTrue();
         Assertions.assertThat(new File(computedJson).createNewFile()).isTrue();
-        System.out.println(FileHelper.printDirectoryTree(new File(output)));
+        log.info("\n{}", FileHelper.printDirectoryTree(new File(output)));
         when(workerConfigService.getTaskOutputDir(CHAIN_TASK_ID)).thenReturn(output);
         when(workerConfigService.getTaskIexecOutDir(CHAIN_TASK_ID)).thenReturn(iexecOut);
 
-        Assertions.assertThat(postComputeService.runStandardPostCompute(taskDescription)).isTrue();
-        System.out.println(FileHelper.printDirectoryTree(new File(output)));
+        Assertions.assertThat(postComputeService.runStandardPostCompute(taskDescription).isSuccessful()).isTrue();
+        log.info("\n{}", FileHelper.printDirectoryTree(new File(output)));
         Assertions.assertThat(new File(output + "/iexec_out.zip")).exists();
         Assertions.assertThat(new File(output + IexecFileHelper.SLASH_COMPUTED_JSON)).exists();
     }
@@ -127,32 +126,39 @@ class PostComputeServiceTests {
     void shouldNotRunStandardPostComputeSinceWrongSourceForZip() throws IOException {
         Assertions.assertThat(new File(iexecOut).mkdir()).isTrue();
         Assertions.assertThat(new File(computedJson).createNewFile()).isTrue();
-        System.out.println(FileHelper.printDirectoryTree(new File(output)));
+        log.info("\n{}", FileHelper.printDirectoryTree(new File(output)));
         when(workerConfigService.getTaskOutputDir(CHAIN_TASK_ID)).thenReturn(output);
         when(workerConfigService.getTaskIexecOutDir(CHAIN_TASK_ID)).thenReturn("dummyIexecOut");
 
-        Assertions.assertThat(postComputeService.runStandardPostCompute(taskDescription)).isFalse();
-        System.out.println(FileHelper.printDirectoryTree(new File(output)));
+        Assertions.assertThat(postComputeService.runStandardPostCompute(taskDescription).isSuccessful()).isFalse();
+        log.info("\n{}", FileHelper.printDirectoryTree(new File(output)));
     }
 
     @Test
     void shouldNotRunStandardPostComputeSinceNoComputedFileToCopy() {
         Assertions.assertThat(new File(iexecOut).mkdir()).isTrue();
         //don't create iexec_out.zip
-        System.out.println(FileHelper.printDirectoryTree(new File(output)));
+        log.info("\n{}", FileHelper.printDirectoryTree(new File(output)));
         when(workerConfigService.getTaskOutputDir(CHAIN_TASK_ID)).thenReturn(output);
         when(workerConfigService.getTaskIexecOutDir(CHAIN_TASK_ID)).thenReturn(iexecOut);
 
-        Assertions.assertThat(postComputeService.runStandardPostCompute(taskDescription)).isFalse();
-        System.out.println(FileHelper.printDirectoryTree(new File(output)));
+        Assertions.assertThat(postComputeService.runStandardPostCompute(taskDescription).isSuccessful()).isFalse();
+        log.info("\n{}", FileHelper.printDirectoryTree(new File(output)));
         Assertions.assertThat(new File(output + "/iexec_out.zip")).exists();
-        Assertions.assertThat(new File(output + IexecFileHelper.SLASH_COMPUTED_JSON).exists()).isFalse();
+        Assertions.assertThat(new File(output + IexecFileHelper.SLASH_COMPUTED_JSON)).doesNotExist();
     }
 
-    /**
-     * Tee post compute
-     */
+    @Test
+    void shouldNotRunStandardPostComputeWhenResultEncryptionRequested() {
+        TaskDescription taskDescription = TaskDescription.builder().isResultEncryption(true).build();
+        PostComputeResponse postComputeResponse = postComputeService.runStandardPostCompute(taskDescription);
+        Assertions.assertThat(postComputeResponse.isSuccessful()).isFalse();
+        Assertions.assertThat(postComputeResponse.getExitCause()).isEqualTo(ReplicateStatusCause.POST_COMPUTE_FAILED_UNKNOWN_ISSUE);
+        //TODO replace exitCause
+    }
+    //endregion
 
+    //region runTeePostCompute
     @Test
     void shouldRunTeePostComputeAndConnectToLasNetwork() {
         String lasNetworkName = "networkName";
@@ -316,4 +322,5 @@ class PostComputeServiceTests {
                 .isEqualTo(ReplicateStatusCause.POST_COMPUTE_TIMEOUT);
         verify(dockerService, times(1)).run(any());
     }
+    //endregion
 }

--- a/src/test/java/com/iexec/worker/compute/post/PostComputeServiceTests.java
+++ b/src/test/java/com/iexec/worker/compute/post/PostComputeServiceTests.java
@@ -151,15 +151,6 @@ class PostComputeServiceTests {
         Assertions.assertThat(new File(output + "/iexec_out.zip")).exists();
         Assertions.assertThat(new File(output + IexecFileHelper.SLASH_COMPUTED_JSON)).doesNotExist();
     }
-
-    @Test
-    void shouldNotRunStandardPostComputeWhenResultEncryptionRequested() {
-        TaskDescription taskDescription = TaskDescription.builder().isResultEncryption(true).build();
-        PostComputeResponse postComputeResponse = postComputeService.runStandardPostCompute(taskDescription);
-        Assertions.assertThat(postComputeResponse.isSuccessful()).isFalse();
-        Assertions.assertThat(postComputeResponse.getExitCause()).isEqualTo(ReplicateStatusCause.POST_COMPUTE_FAILED_UNKNOWN_ISSUE);
-        //TODO replace exitCause
-    }
     //endregion
 
     //region runTeePostCompute

--- a/src/test/java/com/iexec/worker/executor/TaskManagerServiceTests.java
+++ b/src/test/java/com/iexec/worker/executor/TaskManagerServiceTests.java
@@ -118,6 +118,7 @@ class TaskManagerServiceTests {
                 .build();
     }
 
+    //region start
     @Test
     void shouldStart() {
         when(contributionService.isChainTaskInitialized(CHAIN_TASK_ID))
@@ -161,6 +162,18 @@ class TaskManagerServiceTests {
     }
 
     @Test
+    void shouldNotStartSinceStandardTaskWithEncryption() {
+        when(contributionService.getCannotContributeStatusCause(CHAIN_TASK_ID))
+                .thenReturn(Optional.empty());
+        TaskDescription taskDescription = TaskDescription.builder().isResultEncryption(true).build();
+        when(iexecHubService.getTaskDescription(CHAIN_TASK_ID))
+                .thenReturn(taskDescription);
+        ReplicateActionResponse actionResponse = taskManagerService.start(CHAIN_TASK_ID);
+        Assertions.assertThat(actionResponse.isSuccess()).isFalse();
+        Assertions.assertThat(actionResponse.getDetails().getCause()).isEqualTo(TASK_DESCRIPTION_INVALID);
+    }
+
+    @Test
     void shouldNotStartSinceTeeTaskAndButEnabledOnHost() {
         when(contributionService.getCannotContributeStatusCause(CHAIN_TASK_ID))
                 .thenReturn(Optional.empty());
@@ -174,8 +187,9 @@ class TaskManagerServiceTests {
         assertThat(actionResponse.isSuccess()).isFalse();
         assertThat(actionResponse.getDetails().getCause()).isEqualTo(TEE_NOT_SUPPORTED);
     }
+    //endregion
 
-
+    //region downloadApp
     @Test
     void shouldDownloadApp() {
         TaskDescription taskDescription = getStubTaskDescription(false);
@@ -282,8 +296,9 @@ class TaskManagerServiceTests {
         assertThat(actionResponse.isSuccess()).isFalse();
         assertThat(actionResponse.getDetails().getCause()).isEqualTo(POST_COMPUTE_FAILED_UNKNOWN_ISSUE);
     }
+    //endregion
 
-    // downloadData()
+    //region downloadData
 
     /**
      * Note : Remember dataset URI and input files are optional
@@ -602,7 +617,9 @@ class TaskManagerServiceTests {
         assertThat(actionResponse.getDetails().getCause())
                 .isEqualTo(POST_COMPUTE_FAILED_UNKNOWN_ISSUE);
     }
+    //endregion
 
+    //region compute
     @Test
     void shouldCompute() {
         TaskDescription taskDescription = TaskDescription.builder().build();
@@ -793,7 +810,9 @@ class TaskManagerServiceTests {
                 ReplicateActionResponse
                         .failureWithStdout(POST_COMPUTE_FAILED_UNKNOWN_ISSUE, null));
     }
+    //endregion
 
+    //region contribute
     @Test
     void shouldContribute() {
         ComputedFile computedFile = mock(ComputedFile.class);
@@ -938,7 +957,6 @@ class TaskManagerServiceTests {
                 ReplicateActionResponse.failure(CHAIN_RECEIPT_NOT_VALID));
     }
 
-
     @Test
     void shouldNotContributeSinceInvalidContributeChainReceipt() {
         ComputedFile computedFile = mock(ComputedFile.class);
@@ -965,7 +983,9 @@ class TaskManagerServiceTests {
         Assertions.assertThat(replicateActionResponse).isEqualTo(
                 ReplicateActionResponse.failure(CHAIN_RECEIPT_NOT_VALID));
     }
+    //endregion
 
+    //region reveal
     @Test
     void shouldReveal() {
         long consensusBlock = 20;
@@ -1122,7 +1142,9 @@ class TaskManagerServiceTests {
         Assertions.assertThat(replicateActionResponse).isEqualTo(
                 ReplicateActionResponse.failure(CHAIN_RECEIPT_NOT_VALID));
     }
+    //endregion
 
+    //region uploadResult
     @Test
     void shouldUploadResultWithResultUri() {
         String resultUri = "resultUri";
@@ -1171,7 +1193,9 @@ class TaskManagerServiceTests {
         Assertions.assertThat(replicateActionResponse).isEqualTo(
                 ReplicateActionResponse.failure(RESULT_LINK_MISSING));
     }
+    //endregion
 
+    //region complete
     @Test
     void shouldComplete() {
         when(resultService.removeResult(CHAIN_TASK_ID)).thenReturn(true);
@@ -1195,9 +1219,9 @@ class TaskManagerServiceTests {
         Assertions.assertThat(replicateActionResponse).isEqualTo(
                 ReplicateActionResponse.failure());
     }
+    //endregion
 
-    //#region abort()
-
+    //region abort
     @Test
     void shouldAbortTask() {
         when(resultService.removeResult(CHAIN_TASK_ID)).thenReturn(true);
@@ -1210,7 +1234,7 @@ class TaskManagerServiceTests {
         assertThat(predicateCaptor.getValue().test(CHAIN_TASK_ID)).isTrue();
     }
 
-    //#endregion
+    //endregion
 
     //TODO clean theses
     //misc

--- a/src/test/java/com/iexec/worker/result/ResultServiceTests.java
+++ b/src/test/java/com/iexec/worker/result/ResultServiceTests.java
@@ -242,6 +242,36 @@ class ResultServiceTests {
         ComputedFile computedFile = resultService.getComputedFile(chainTaskId);
         Assertions.assertThat(computedFile).isNull();
     }
+
+    @Test
+    void shouldNotComputeWeb2ResultDigestWhenFileTreeNotFound() {
+        String chainTaskId = "deterministic-output-directory-missing";
+        when(workerConfigurationService.getTaskOutputDir(chainTaskId))
+                .thenReturn(IEXEC_WORKER_TMP_FOLDER + chainTaskId + "/output");
+        when(iexecHubService.getTaskDescription(chainTaskId)).thenReturn(
+                TaskDescription.builder().callback(BytesUtils.EMPTY_ADDRESS).build());
+        ComputedFile computedFile = resultService.getComputedFile(chainTaskId);
+        Assertions.assertThat(computedFile).isNull();
+        computedFile = resultService.readComputedFile(chainTaskId);
+        Assertions.assertThat(computedFile).isNotNull();
+        String resultDigest = resultService.computeResultDigest(computedFile);
+        Assertions.assertThat(resultDigest).isEmpty();
+    }
+
+    @Test
+    void shouldNotComputeWeb3ResultDigestWhenNoCallbackData() {
+        String chainTaskId = "callback-no-data";
+        when(workerConfigurationService.getTaskOutputDir(chainTaskId))
+                .thenReturn(IEXEC_WORKER_TMP_FOLDER + chainTaskId + "/output");
+        when(iexecHubService.getTaskDescription(chainTaskId)).thenReturn(
+                TaskDescription.builder().callback(CALLBACK).build());
+        ComputedFile computedFile = resultService.getComputedFile(chainTaskId);
+        Assertions.assertThat(computedFile).isNull();
+        computedFile = resultService.readComputedFile(chainTaskId);
+        Assertions.assertThat(computedFile).isNotNull();
+        String resultDigest = resultService.computeResultDigest(computedFile);
+        Assertions.assertThat(resultDigest).isEmpty();
+    }
     //endregion
 
     //region writeComputedFile

--- a/src/test/resources/tmp/test-worker/callback-no-data/output/computed.json
+++ b/src/test/resources/tmp/test-worker/callback-no-data/output/computed.json
@@ -1,0 +1,3 @@
+{
+  "callback-data": ""
+}

--- a/src/test/resources/tmp/test-worker/deterministic-output-directory-missing/output/computed.json
+++ b/src/test/resources/tmp/test-worker/deterministic-output-directory-missing/output/computed.json
@@ -1,0 +1,3 @@
+{
+  "deterministic-output-path": "/iexec_out"
+}


### PR DESCRIPTION
Improve runTaskCompute status for standard task and computed.json file analysis.

There are 2 things to note

This should be changed
https://github.com/iExecBlockchainComputing/iexec-worker/blob/bugfix/run-post-compute-status/src/main/java/com/iexec/worker/compute/post/PostComputeService.java#L73
Suggestion : `POST_COMPUTE_ENCRYPTION_NOT_SUPPORTED` ?

The `getComputedFile` is used in `TaskManagerService` and `ReplicateRecoveryService`.
To limit impacts, I preferred to add a `readComputedFile` method in `ResultService` instead of throwing exceptions with impacts in other services.