### PR TITLE
Bugfix/enforce non null exit cause on pre or post compute failure

### DIFF
--- a/src/main/java/com/iexec/worker/compute/ComputeExitCauseService.java
+++ b/src/main/java/com/iexec/worker/compute/ComputeExitCauseService.java
@@ -74,7 +74,7 @@ public class ComputeExitCauseService {
         ComputeStage stage = ComputeStage.PRE;
         ReplicateStatusCause cause = getReplicateStatusCause(stage, chainTaskId);
         pruneExitCause(stage, chainTaskId);
-        return cause;
+        return cause != null ? cause : ReplicateStatusCause.PRE_COMPUTE_FAILED_UNKNOWN_ISSUE;
     }
 
     /**
@@ -87,7 +87,7 @@ public class ComputeExitCauseService {
         ComputeStage stage = ComputeStage.POST;
         ReplicateStatusCause cause = getReplicateStatusCause(stage, chainTaskId);
         pruneExitCause(stage, chainTaskId);
-        return cause;
+        return cause != null ? cause : ReplicateStatusCause.POST_COMPUTE_FAILED_UNKNOWN_ISSUE;
     }
 
     /**

--- a/src/test/java/com/iexec/worker/compute/ComputeExitCauseServiceTests.java
+++ b/src/test/java/com/iexec/worker/compute/ComputeExitCauseServiceTests.java
@@ -32,6 +32,7 @@ class ComputeExitCauseServiceTests {
         computeExitCauseService = new ComputeExitCauseService();
     }
 
+    //region getPreComputeExitCauseAndPrune
     @Test
     void setAndGetPreComputeExitCauseAndPrune() {
         ReplicateStatusCause cause =
@@ -46,6 +47,16 @@ class ComputeExitCauseServiceTests {
     }
 
     @Test
+    void shouldReturnUnknownIssueWhenPreComputeExitCauseNotSet() {
+        ReplicateStatusCause cause = computeExitCauseService.getPreComputeExitCauseAndPrune(CHAIN_TASK_ID);
+        Assertions.assertThat(cause)
+                .isNotNull()
+                .isEqualTo(ReplicateStatusCause.PRE_COMPUTE_FAILED_UNKNOWN_ISSUE);
+    }
+    //endregion
+
+    //region getPostComputeExitCauseAndPrune
+    @Test
     void setAndGetPostComputeExitCauseAndPrune() {
         ReplicateStatusCause cause =
                 ReplicateStatusCause.POST_COMPUTE_COMPUTED_FILE_NOT_FOUND;
@@ -57,6 +68,15 @@ class ComputeExitCauseServiceTests {
         Assertions.assertThat(computeExitCauseService.getReplicateStatusCause(ComputeStage.POST,
                 CHAIN_TASK_ID)).isNull();
     }
+
+    @Test
+    void shouldReturnUnknownIssueWhenPostComputeExitCauseNotSet() {
+        ReplicateStatusCause cause = computeExitCauseService.getPostComputeExitCauseAndPrune(CHAIN_TASK_ID);
+        Assertions.assertThat(cause)
+                .isNotNull()
+                .isEqualTo(ReplicateStatusCause.POST_COMPUTE_FAILED_UNKNOWN_ISSUE);
+    }
+    //endregion
 
     @Test
     void shouldNotSetComputeExitCauseSinceAlreadySet() {

--- a/src/test/java/com/iexec/worker/compute/post/PostComputeServiceTests.java
+++ b/src/test/java/com/iexec/worker/compute/post/PostComputeServiceTests.java
@@ -30,7 +30,6 @@ import com.iexec.worker.compute.TeeWorkflowConfiguration;
 import com.iexec.worker.config.WorkerConfigurationService;
 import com.iexec.worker.docker.DockerService;
 import com.iexec.worker.sgx.SgxService;
-import com.iexec.worker.tee.scone.SconeConfiguration;
 import com.iexec.worker.tee.scone.TeeSconeService;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
@@ -60,7 +59,6 @@ class PostComputeServiceTests {
 
     private final static String CHAIN_TASK_ID = "CHAIN_TASK_ID";
     private final static String DATASET_URI = "DATASET_URI";
-    private final static String SCONE_CAS_URL = "SCONE_CAS_URL";
     private final static String WORKER_NAME = "WORKER_NAME";
     private final static String TEE_POST_COMPUTE_IMAGE = "TEE_POST_COMPUTE_IMAGE";
     private final static long TEE_POST_COMPUTE_HEAP = 1024;
@@ -87,8 +85,6 @@ class PostComputeServiceTests {
     @Mock
     private TeeSconeService teeSconeService;
     @Mock
-    private SconeConfiguration sconeConfig;
-    @Mock
     private TeeWorkflowConfiguration teeWorkflowConfig;
     @Mock
     private DockerClientInstance dockerClientInstanceMock;
@@ -101,7 +97,6 @@ class PostComputeServiceTests {
     void beforeEach() {
         MockitoAnnotations.openMocks(this);
         when(dockerService.getClient()).thenReturn(dockerClientInstanceMock);
-        when(sconeConfig.getCasUrl()).thenReturn(SCONE_CAS_URL);
         output = jUnitTemporaryFolder.getAbsolutePath();
         iexecOut = output + IexecFileHelper.SLASH_IEXEC_OUT;
         computedJson = iexecOut + IexecFileHelper.SLASH_COMPUTED_JSON;

--- a/src/test/java/com/iexec/worker/compute/pre/PreComputeServiceTests.java
+++ b/src/test/java/com/iexec/worker/compute/pre/PreComputeServiceTests.java
@@ -30,12 +30,10 @@ import com.iexec.sms.api.TeeSessionGenerationError;
 import com.iexec.worker.compute.ComputeExitCauseService;
 import com.iexec.worker.compute.TeeWorkflowConfiguration;
 import com.iexec.worker.config.WorkerConfigurationService;
-import com.iexec.worker.dataset.DataService;
 import com.iexec.worker.docker.DockerService;
 import com.iexec.worker.sgx.SgxService;
 import com.iexec.worker.sms.SmsService;
 import com.iexec.worker.sms.TeeSessionGenerationException;
-import com.iexec.worker.tee.scone.SconeConfiguration;
 import com.iexec.worker.tee.scone.TeeSconeService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,13 +81,9 @@ class PreComputeServiceTests {
     @Mock
     private SmsService smsService;
     @Mock
-    private DataService dataService;
-    @Mock
     private DockerService dockerService;
     @Mock
     private TeeSconeService teeSconeService;
-    @Mock
-    private SconeConfiguration sconeConfig;
     @Mock
     private WorkerConfigurationService workerConfigService;
     @Mock


### PR DESCRIPTION
Enforce a non  null value when looking for exit cause on pre/post compute failure.

I wanted to try to improve `PreComputeServiceTests` and `PostComputeServiceTests` but it is a real refactoring with the current implementation.

It would require:

* to remove `@InjectMocks`
* to remove `@Mock` annotation on `ComputeExitCauseService` and use the real class
* to construct `PreComputeService` and `PostComputeService` instances by injecting a mix of mocked and non-mocked classes
* to use (or not) `setExitCause` to check the behaviors of `getPreComputeExitCauseAndPrune` and `getPostComputeExitCauseAndPrune`

I let you tell me if there is value right now in such a rework.