### PR TITLE
Feature/refactor login service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 * Remove dataset decryption non-TEE workflow.
 * Purge result files and metadata when task is completed.
+* On _iExec Core Scheduler_ REST call failure, only try to log in once to avoid nested retry loops.
 ### Quality
 * Improve code quality.
 ### Dependency Upgrades

--- a/src/main/java/com/iexec/worker/feign/BaseFeignClient.java
+++ b/src/main/java/com/iexec/worker/feign/BaseFeignClient.java
@@ -64,6 +64,7 @@ public abstract class BaseFeignClient {
 
         while (shouldRetry(infiniteRetry, attempt, status)) {
             try {
+                // FIXME: what happens when several authenticated REST calls are executed in parallel and get HTTP 4xx ?
                 return call.apply(args);
             } catch (FeignException e) {
                 status = e.status();

--- a/src/main/java/com/iexec/worker/feign/LoginService.java
+++ b/src/main/java/com/iexec/worker/feign/LoginService.java
@@ -26,6 +26,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.web3j.crypto.ECKeyPair;
 
+import java.util.Objects;
+
 @Slf4j
 @Service
 public class LoginService {
@@ -46,6 +48,7 @@ public class LoginService {
     }
 
     public String login() {
+        final String oldToken = jwtToken;
         expireToken();
 
         String workerAddress = credentialsService.getCredentials().getAddress();
@@ -74,8 +77,8 @@ public class LoginService {
             return "";
         }
 
-        log.info("Retrieved new token {}", token);
         jwtToken = TOKEN_PREFIX + token;
+        log.info("Retrieved {} JWT token from scheduler", Objects.equals(oldToken, jwtToken) ? "existing" : "new");
         return jwtToken;
     }
 

--- a/src/main/java/com/iexec/worker/feign/LoginService.java
+++ b/src/main/java/com/iexec/worker/feign/LoginService.java
@@ -46,7 +46,7 @@ public class LoginService {
     }
 
     public String login() {
-        jwtToken = "";
+        expireToken();
 
         String workerAddress = credentialsService.getCredentials().getAddress();
         ECKeyPair ecKeyPair = credentialsService.getCredentials().getEcKeyPair();
@@ -76,5 +76,9 @@ public class LoginService {
 
         jwtToken = TOKEN_PREFIX + token;
         return jwtToken;
+    }
+
+    public void expireToken() {
+        jwtToken = "";
     }
 }

--- a/src/main/java/com/iexec/worker/feign/LoginService.java
+++ b/src/main/java/com/iexec/worker/feign/LoginService.java
@@ -26,12 +26,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.web3j.crypto.ECKeyPair;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @Slf4j
 @Service
-public class LoginService extends BaseFeignClient {
+public class LoginService {
 
     static final String TOKEN_PREFIX = "Bearer ";
     private String jwtToken;
@@ -48,21 +45,30 @@ public class LoginService extends BaseFeignClient {
         return jwtToken;
     }
 
-    @Override
     public String login() {
-        expireToken();
+        jwtToken = "";
 
         String workerAddress = credentialsService.getCredentials().getAddress();
         ECKeyPair ecKeyPair = credentialsService.getCredentials().getEcKeyPair();
 
-        String challenge = getLoginChallenge(workerAddress);
+        ResponseEntity<String> challengeResponse = coreClient.getChallenge(workerAddress);
+        if (!challengeResponse.getStatusCode().is2xxSuccessful()) {
+            log.error("Failed to get challenge [status:{}]", challengeResponse.getStatusCode());
+            return "";
+        }
+        String challenge = challengeResponse.getBody();
         if (StringUtils.isEmpty(challenge)) {
             log.error("Cannot login since challenge is empty [challenge:{}]", challenge);
             return "";
         }
 
         Signature signature = SignatureUtils.hashAndSign(challenge, workerAddress, ecKeyPair);
-        String token = requestLogin(workerAddress, signature);
+        ResponseEntity<String> tokenResponse = coreClient.login(workerAddress, signature);
+        if (!tokenResponse.getStatusCode().is2xxSuccessful()) {
+            log.error("Failed to login [status:{}]", tokenResponse.getStatusCode());
+            return "";
+        }
+        String token = tokenResponse.getBody();
         if (StringUtils.isEmpty(token)) {
             log.error("Cannot login since token is empty [token:{}]", token);
             return "";
@@ -70,26 +76,5 @@ public class LoginService extends BaseFeignClient {
 
         jwtToken = TOKEN_PREFIX + token;
         return jwtToken;
-    }
-
-    private void expireToken() {
-        jwtToken = "";
-    }
-
-    private String getLoginChallenge(String workerAddress) {
-        Map<String, Object> arguments = new HashMap<>();
-        arguments.put("workerAddress", workerAddress);
-        HttpCall<String> httpCall = args -> coreClient.getChallenge((String) args.get("workerAddress"));
-        ResponseEntity<String> response = makeHttpCall(httpCall, arguments, "getLoginChallenge");
-        return is2xxSuccess(response) && response.getBody() != null ? response.getBody() : "";
-    }
-
-    private String requestLogin(String workerAddress, Signature signature) {
-        Map<String, Object> arguments = new HashMap<>();
-        arguments.put("workerAddress", workerAddress);
-        arguments.put("signature", signature);
-        HttpCall<String> httpCall = args -> coreClient.login((String) args.get("workerAddress"), (Signature) args.get("signature"));
-        ResponseEntity<String> response = makeHttpCall(httpCall, arguments, "requestLogin");
-        return is2xxSuccess(response) && response.getBody() != null ? response.getBody() : "";
     }
 }

--- a/src/main/java/com/iexec/worker/feign/LoginService.java
+++ b/src/main/java/com/iexec/worker/feign/LoginService.java
@@ -82,7 +82,7 @@ public class LoginService {
         return jwtToken;
     }
 
-    public void expireToken() {
+    private void expireToken() {
         jwtToken = "";
     }
 }

--- a/src/main/java/com/iexec/worker/feign/LoginService.java
+++ b/src/main/java/com/iexec/worker/feign/LoginService.java
@@ -53,27 +53,28 @@ public class LoginService {
 
         ResponseEntity<String> challengeResponse = coreClient.getChallenge(workerAddress);
         if (!challengeResponse.getStatusCode().is2xxSuccessful()) {
-            log.error("Failed to get challenge [status:{}]", challengeResponse.getStatusCode());
+            log.error("Cannot login, failed to get challenge [status:{}]", challengeResponse.getStatusCode());
             return "";
         }
         String challenge = challengeResponse.getBody();
         if (StringUtils.isEmpty(challenge)) {
-            log.error("Cannot login since challenge is empty [challenge:{}]", challenge);
+            log.error("Cannot login, challenge is empty [challenge:{}]", challenge);
             return "";
         }
 
         Signature signature = SignatureUtils.hashAndSign(challenge, workerAddress, ecKeyPair);
         ResponseEntity<String> tokenResponse = coreClient.login(workerAddress, signature);
         if (!tokenResponse.getStatusCode().is2xxSuccessful()) {
-            log.error("Failed to login [status:{}]", tokenResponse.getStatusCode());
+            log.error("Cannot login, failed to get token [status:{}]", tokenResponse.getStatusCode());
             return "";
         }
         String token = tokenResponse.getBody();
         if (StringUtils.isEmpty(token)) {
-            log.error("Cannot login since token is empty [token:{}]", token);
+            log.error("Cannot login, token is empty [token:{}]", token);
             return "";
         }
 
+        log.info("Retrieved new token {}", token);
         jwtToken = TOKEN_PREFIX + token;
         return jwtToken;
     }


### PR DESCRIPTION
Call to login is already part of retry mechanisms for authenticated endpoints.
Remove retries on login endpoints to avoid nested loops.
Login endpoints will be called once each time an authenticated request fails with a 4xx status code.